### PR TITLE
Fix #39 - Anchor links in emails are broken

### DIFF
--- a/code/email/NewsletterEmail.php
+++ b/code/email/NewsletterEmail.php
@@ -86,6 +86,12 @@ class NewsletterEmail extends Email {
 					arsort($sorted);
 
 					foreach($sorted as $link => $length) {
+						// Don't replace anchor links
+						if ($link[0] == '#') {
+							$replacements[$link] = $link; // A null replacement
+							continue;
+						}
+						
 						$SQL_link = Convert::raw2sql($link);
 
 						$tracked = DataObject::get_one('Newsletter_TrackedLink',


### PR DESCRIPTION
Will avoid replacing the link if the first character is a #
