### PR TITLE
FIX Prevent failing emails stopping entire queue

### DIFF
--- a/code/controller/NewsletterSendController.php
+++ b/code/controller/NewsletterSendController.php
@@ -214,7 +214,12 @@ class NewsletterSendController extends BuildTask {
 
 						//send out the mails
 						foreach($queueItems2 as $item) {
-							$item->send($newsletter, $recipientsMap[$item->RecipientID]);
+							try {
+								$item->send($newsletter, $recipientsMap[$item->RecipientID]);
+							} catch (Exception $e) {
+								$item->Status = 'Failed';
+								$item->write();
+							}
 						}
 					}
 


### PR DESCRIPTION
Previous to this, certain rare conditions could case the sender to fail and require a manual restart.
Now, it'll mark an email as failed as soon as we get an exception.
