### PR TITLE
FIX: Always return DataList when getting ActiveRecipients, avoid logic e...

### DIFF
--- a/code/model/MailingList.php
+++ b/code/model/MailingList.php
@@ -114,6 +114,6 @@ class MailingList extends DataObject {
 	 * Returns all recipients who aren't blacklisted, and are verified.
 	 */
 	public function ActiveRecipients() {
-		return $this->Recipients()->exclude('Blacklisted', 1)->exclude('Verified', 0);
+		return $this->Recipients()->exists() ? $this->Recipients()->exclude('Blacklisted', 1)->exclude('Verified', 0) : DataList::create('Recipient');
 	}
 }


### PR DESCRIPTION
...rror

CMS throwing logic error (related to UnsavedRelationList) when
accessing the MailingList modeladmin. Fixed this by checking if
recipients exists, and returning an empty DataList if none do exist
