### PR TITLE
FIX: MailingList ModelAdmin throwing Logic Error when no Recipients or Mailing Lists in DB

### DIFF
--- a/code/model/MailingList.php
+++ b/code/model/MailingList.php
@@ -114,9 +114,6 @@ class MailingList extends DataObject {
 	 * Returns all recipients who aren't blacklisted, and are verified.
 	 */
 	public function ActiveRecipients() {
-		return $this->Recipients()->exists() ? $this->Recipients()->exclude(array(
-			'Blacklisted' => 0,
-			'Verified' => 0
-		)) : ArrayList::create();
+		return $this->Recipients()->exists() ? $this->Recipients()->exclude('Blacklisted', 1)->exclude('Verified', 0) : ArrayList::create();
 	}
 }


### PR DESCRIPTION
Made sure MailingList::ActiveRecipients always returns a DataList rather than an UnsavedRelationList
