### PR TITLE
ENH customise confirm delete messages for clarity

### DIFF
--- a/javascript/ActionOnConfirmation.js
+++ b/javascript/ActionOnConfirmation.js
@@ -16,8 +16,17 @@
 
 		$("#Form_ItemEditForm_action_doDelete").entwine({
 			onclick: function(e) {
+				// customise confirm delete messages for clarity
+				var item = 'record';
+				var pageAction = $('#Form_ItemEditForm').attr('action');
+				if(pageAction.indexOf('ItemEditForm/field/Recipients/item/') != -1){
+					item = 'Recipient';
+				}else if(pageAction.indexOf('admin/newsletter/MailingList/EditForm/field/MailingList/') == 0){
+					item = 'Mailing List';
+				}
 				var message = ss.i18n._t('NEWSLETTERADMIN.DELETECONFIRMMESSAGE',
-					'Are you sure you want to delete this record?');
+					'Are you sure you want to delete this '+item+'?');
+					
 				if (confirm(message)) {
 					this._super(e);
 				} else {


### PR DESCRIPTION
Delete confirmation messages should really be a generic silverstripe framework thing, but this is good for the mean time
