### PR TITLE
Bug fix - str replacement with forward slash

### DIFF
--- a/code/email/NewsletterEmail.php
+++ b/code/email/NewsletterEmail.php
@@ -109,7 +109,12 @@ class NewsletterEmail extends Email {
 						}
 						
 						// replace the link
-						$replacements[$link] = $tracked->Link();
+						if($link == '/'){
+							$link = '"/"';
+							$replacements[$link] = '"' . $tracked->Link() . '"';
+						}else{
+							$replacements[$link] = $tracked->Link();
+						}
 						
 						// track that this link is still active
 						$current[] = $tracked->ID;


### PR DESCRIPTION
when href="/", value of $link is forward slash symbol. All forward slashes in HTML like </p> will be replaced with tracking link and layout will be broken. Should search and replace '"/"'.
