### PR TITLE
Fix compatibity issue with BetterButtons

### DIFF
--- a/code/pagetypes/SubscriptionPage.php
+++ b/code/pagetypes/SubscriptionPage.php
@@ -399,7 +399,10 @@ JS
 
 		//filter weird characters
 		$data['Email'] = preg_replace("/[^a-zA-Z0-9\._\-@]/","",$data['Email']);
-
+		if (filter_var($data['Email'], FILTER_VALIDATE_EMAIL) === false) {
+			$form->addErrorMessage("Email", "Please enter a valid email", "bad");
+			return $this->redirectBack();
+		}
 		// check to see if member already exists
 		$recipient = false;
 


### PR DESCRIPTION
Better buttons changes the save action name to ```action_save```, while newsletter expects it to be ```action_doSave```.
This does a simple check to see if ```action_doSave``` exists, if it does not, it will use ```action_save```